### PR TITLE
統合テスト追加手順

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem 'rspec-rails'
   gem 'factory_bot_rails'
   gem 'rails-controller-testing'
+  gem 'capybara'
 end
 
 group :development do
@@ -63,7 +64,6 @@ end
 
 group :test do
   # Adds support for Capybara system testing and selenium driver
-  gem 'capybara', '>= 2.15'
   gem 'selenium-webdriver'
   # Easy installation and use of chromedriver to run system tests with Chrome
   gem 'chromedriver-helper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -266,7 +266,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
-  capybara (>= 2.15)
+  capybara
   chromedriver-helper
   coffee-rails (~> 4.2)
   compass-rails (= 3.1.0)

--- a/app/views/tweets/_form.html.erb
+++ b/app/views/tweets/_form.html.erb
@@ -1,3 +1,3 @@
-<%= form.text_field :image, placeholder: "Image Url" %>
-<%= form.text_area :text, placeholder: "text" , rows: "10" %>
+<%= form.text_field :image, placeholder: "Image Url", id: "image" %>
+<%= form.text_area :text, placeholder: "text" , rows: "10", id: "test" %>
 <%= form.submit "SEND" %>

--- a/spec/features/tweet_spec.rb
+++ b/spec/features/tweet_spec.rb
@@ -1,0 +1,2 @@
+require 'rails_helper'
+

--- a/spec/features/tweet_spec.rb
+++ b/spec/features/tweet_spec.rb
@@ -1,2 +1,4 @@
 require 'rails_helper'
 
+feature 'tweet', type: :feature do
+end

--- a/spec/features/tweet_spec.rb
+++ b/spec/features/tweet_spec.rb
@@ -1,4 +1,11 @@
 require 'rails_helper'
 
 feature 'tweet', type: :feature do
+  given(:user) { create(:user) }
+
+  scenario 'ユーザー情報が更新されていること' do
+    # ログイン前には投稿ボタンがない
+    visit root_path
+    expect(page).to have_no_content('投稿する')
+  end
 end

--- a/spec/features/tweet_spec.rb
+++ b/spec/features/tweet_spec.rb
@@ -15,5 +15,14 @@ feature 'tweet', type: :feature do
     find('input[name="commit"]').click
     expect(current_path).to eq root_path
     expect(page).to have_content('投稿する')
+
+    # ツイートの投稿
+    expect {
+      click_link('投稿する')
+      expect(current_path).to eq new_tweet_path
+      fill_in 'image', with: 'https://s.eximg.jp/expub/feed/Papimami/2016/Papimami_83279/Papimami_83279_1.png'
+      fill_in 'text', with: 'フィーチャスペックのテスト'
+      find('input[type="submit"]').click
+    }.to change(Tweet, :count).by(1)
   end
 end

--- a/spec/features/tweet_spec.rb
+++ b/spec/features/tweet_spec.rb
@@ -7,5 +7,13 @@ feature 'tweet', type: :feature do
     # ログイン前には投稿ボタンがない
     visit root_path
     expect(page).to have_no_content('投稿する')
+
+    # ログイン処理
+    visit new_user_session_path
+    fill_in 'user_email', with: user.email
+    fill_in 'user_password', with: user.password
+    find('input[name="commit"]').click
+    expect(current_path).to eq root_path
+    expect(page).to have_content('投稿する')
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,7 @@ require File.expand_path('../config/environment', __dir__)
 abort("The Rails environment is running in production mode!") if Rails.env.production?
 require 'rspec/rails'
 # Add additional requires below this line. Rails is not loaded until this point!
-
+require 'capybara/rspec'
 # Requires supporting ruby files with custom matchers and macros, etc, in
 # spec/support/ and its subdirectories. Files matching `spec/**/*_spec.rb` are
 # run as spec files by default. This means that files in spec/support that end


### PR DESCRIPTION
# 1.AddCapybara
## What
CapybaraGemを追加します。

## Why
統合テストを行えるようにするためです。

# 2.RequireCapybara
## What
spec/rails_helper.rbにrequire 'capybara/rspec'を追記しました。

## Why
rspecでcapybaraを使えるようにするためです。

# 3.ModifyForm
## What
form_withのinput要素にidを付与しました。

## Why
Capybaraでは、idを付与しないとテストが行えないためです。

# 4.CreateFeaturesTweetSpec
## What
specディレクトリの下にfeaturesディレクトリを作成し、その下にtweet_spec.rbを追加しました。

## Why

# 5.AddRequire
## What
tweet_spec.rbの1行目にrequire 'rails_helper'を追加しました。

## Why
テストコードでは1行目に記述するルールのためです。

# 6.AddFeatureTemplate
## What
tweet_spec.rbに統合テストの雛形を記述しました。

## Why
統合テストに利用する記述だからです。

# 7.AddSampleTest
## What
ログイン前のユーザーでは投稿するボタンが表示されていないことを確認します。

## Why
仕様と動作が一致していることのチェックです。

# 8.CheckLogin
## What
ログインできることを確かめます。

## Why
仕様と動作が一致していることのチェックです。


# 9.CheckTweet
## What
Tweetが投稿できることをテストします。

## Why
仕様と動作が一致していることのチェックです。
